### PR TITLE
add overflow: hidden to popover component

### DIFF
--- a/assets/sass/components/popover.scss
+++ b/assets/sass/components/popover.scss
@@ -30,6 +30,7 @@
     line-height: 28px;
     padding: 0 $gutter;
     @include font(13px, 600);
+    overflow: hidden;
   }
   a:hover {
     background-color: $grey--lighter;


### PR DESCRIPTION
In response to bootiq ugly popover bug.